### PR TITLE
Fix make env target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ $(CONFIG):
 # $(ENV): Prints the evaluated docker compose default env configuration.
 #
 $(ENV):
-	@source $(COMPOSE_ENV_FILE) && \
+	@. ./$(COMPOSE_ENV_FILE) && \
 	awk -F '=' '/^[^#]/ { \
 		gsub(/^[[:space:]]+|[[:space:]]+$$/, ""); \
 		value = ENVIRON[$$1]; \


### PR DESCRIPTION
## Summary
- fix sourcing of env file in Makefile

## Testing
- `make env > /tmp/env_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_6848bc914e208322a854f1cce091c009