### PR TITLE
Fix Davy Jones spelling in config docs

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -11,7 +11,7 @@ Ahoy, ye scurvy devils! Welcome to the **`config`** directory of the grand vesse
 |------------------|------------------------------------------------------|
 | 🏴‍☠️ `bazarr`         | Subtitle swabbie, makin' sure ye always read what's said |
 | 🧹 `cleanuperr`     | Cleans up the seas of orphaned files and debris     |
-| 💾 `duplicati`      | Backup ye booty — protect it from Davey Jones       |
+| 💾 `duplicati`      | Backup ye booty — protect it from Davy Jones        |
 | 🌩️ `flaresolverr`   | Bypasses cloudflare storms to get yer bounty        |
 | 🛡️ `gluetun`        | VPN shieldin' yer traffic from nosy navies          |
 | 🗺️ `homepage`       | Central map to all yer ports — a true dashboard     |


### PR DESCRIPTION
## Summary
- fix the Duplicati description to mention "Davy Jones" correctly

## Testing
- `grep -n "Davy Jones" -n config/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6848c962212c8322a0c1205091abc169