### PR TITLE
📣 Let Maraudarr serve Discord shipyard gossip 🏳️‍🌈

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -95,6 +95,124 @@ jobs:
       IMAGE_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
     steps:
+      - name: "Notify Discord: shipyard opened 📣"
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          REPOSITORY: ${{ github.repository }}
+          GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_IMAGE }}
+          IMAGE_PLATFORMS: ${{ env.IMAGE_PLATFORMS }}
+        run: |
+          if [ -z "${DISCORD_WEBHOOK_URL}" ]; then
+              echo "DISCORD_WEBHOOK_URL is not set; skipping Discord notification."
+              exit 0
+          fi
+
+          embed_colors=(16711884 15961002 11685080 10181046 15844367 16738740)
+          color="${embed_colors[$((RANDOM % ${#embed_colors[@]}))]}"
+
+          payload="$(jq -n \
+              --arg title "🏴‍☠️ Maraudarr entered the shipyard, divas" \
+              --arg description "${WORKFLOW_NAME} slapped on a tricorn and ordered a multi-arch fleet. OSHA has left the chat." \
+              --arg url "${RUN_URL}" \
+              --arg repository "${REPOSITORY}" \
+              --arg ref "${REF_NAME}" \
+              --arg actor "${ACTOR}" \
+              --arg platforms "${IMAGE_PLATFORMS}" \
+              --arg ghcr "${GHCR_IMAGE}" \
+              --arg dockerhub "${DOCKERHUB_IMAGE}" \
+              --argjson color "${color}" \
+              '{
+                username: "Maraudarr Deck Crew",
+                embeds: [{
+                  title: $title,
+                  description: $description,
+                  url: $url,
+                  color: $color,
+                  fields: [
+                    {name: "🗺️ Gossip Map", value: $repository, inline: true},
+                    {name: "🌿 Serving Ref", value: $ref, inline: true},
+                    {name: "💅 Chaos Commodore", value: $actor, inline: true},
+                    {name: "🧱 Three-Way Fleet", value: $platforms, inline: false},
+                    {name: "📦 GHCR Treasure Chest", value: $ghcr, inline: false},
+                    {name: "🐳 Docker Hub Cruise", value: $dockerhub, inline: false}
+                  ],
+                  footer: {text: "Maraudarr shipyard: queer, seaworthy, over-accessorized"},
+                  timestamp: now | todate
+                }]
+              }')"
+
+          curl \
+              --fail \
+              --silent \
+              --show-error \
+              --header "Content-Type: application/json" \
+              --data "${payload}" \
+              "${DISCORD_WEBHOOK_URL}"
+
+      - name: "Notify Hades Discord: kraken awakened 🦑"
+        env:
+          DISCORD_HADES_HOOK_URL: ${{ secrets.DISCORD_HADES_HOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          REPOSITORY: ${{ github.repository }}
+          GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_IMAGE }}
+          IMAGE_PLATFORMS: ${{ env.IMAGE_PLATFORMS }}
+        run: |
+          if [ -z "${DISCORD_HADES_HOOK_URL}" ]; then
+              echo "DISCORD_HADES_HOOK_URL is not set; skipping Hades Discord notification."
+              exit 0
+          fi
+
+          embed_colors=(16711884 15961002 11685080 10181046 15844367 16738740)
+          color="${embed_colors[$((RANDOM % ${#embed_colors[@]}))]}"
+
+          payload="$(jq -n \
+              --arg title "🦑 The kraken put on eyeliner. Build time." \
+              --arg description "${WORKFLOW_NAME} sashayed into dry dock with a cutlass, a blueprint, and absolutely no indoor voice." \
+              --arg url "${RUN_URL}" \
+              --arg repository "${REPOSITORY}" \
+              --arg ref "${REF_NAME}" \
+              --arg actor "${ACTOR}" \
+              --arg platforms "${IMAGE_PLATFORMS}" \
+              --arg ghcr "${GHCR_IMAGE}" \
+              --arg dockerhub "${DOCKERHUB_IMAGE}" \
+              --argjson color "${color}" \
+              '{
+                username: "Kraken Build Bureau",
+                embeds: [{
+                  title: $title,
+                  description: $description,
+                  url: $url,
+                  color: $color,
+                  fields: [
+                    {name: "⚓ Wet Little Repo", value: $repository, inline: true},
+                    {name: "💄 Glossy Ref", value: $ref, inline: true},
+                    {name: "🧜 Summoning Siren", value: $actor, inline: true},
+                    {name: "🧱 Tentacle Rack", value: $platforms, inline: false},
+                    {name: "📦 GHCR Booty", value: $ghcr, inline: false},
+                    {name: "🐳 Docker Diva Dock", value: $dockerhub, inline: false}
+                  ],
+                  footer: {text: "Kraken Build Bureau: salty, sparkly, OCI-compliant"},
+                  timestamp: now | todate
+                }]
+              }')"
+
+          curl \
+              --fail \
+              --silent \
+              --show-error \
+              --header "Content-Type: application/json" \
+              --data "${payload}" \
+              "${DISCORD_HADES_HOOK_URL}"
+
       - name: "Grab the Treasure Map 🗺️"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -208,3 +326,151 @@ jobs:
           repository: ${{ github.repository_owner }}/maraudarr
           short-description: "Generate polished Plundarr Docker Compose stacks from presets and selectable services."
           readme-filepath: ./docs/DOCKERHUB_README.md
+
+      - name: "Notify Discord: fleet gossip 📣"
+        if: always()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
+          GHCR_PACKAGE_URL: ${{ github.server_url }}/${{ github.repository }}/pkgs/container/maraudarr
+          DOCKERHUB_URL: https://hub.docker.com/r/${{ github.repository_owner }}/maraudarr
+          PUBLISHED_TAGS: ${{ steps.metadata.outputs.tags }}
+          PUBLISHED_DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          if [ -z "${DISCORD_WEBHOOK_URL}" ]; then
+              echo "DISCORD_WEBHOOK_URL is not set; skipping Discord notification."
+              exit 0
+          fi
+
+          if [ "${JOB_STATUS}" = "success" ]; then
+              title="✅ Fleet launched. Wig secured."
+              description="Fresh Maraudarr images are serving multi-arch realness. The registries have been boarded and nobody chipped a nail."
+          else
+              title="💥 Shipwreck, but make it fashion"
+              description="The Maraudarr voyage ended ${JOB_STATUS}. Somebody fetch the logs, the lifeboats, and a stronger setting spray."
+          fi
+          embed_colors=(16711884 15961002 11685080 10181046 15844367 16738740)
+          color="${embed_colors[$((RANDOM % ${#embed_colors[@]}))]}"
+
+          formatted_tags="$(printf '%s\n' "${PUBLISHED_TAGS:-none}" \
+              | sed '/^$/d; s#^'"${GHCR_IMAGE}"':##; s/^/• /')"
+          [ -n "${formatted_tags}" ] || formatted_tags="none"
+          digest_short="$(printf '%s' "${PUBLISHED_DIGEST:-unavailable}" \
+              | sed -E 's/^(sha256:[0-9a-f]{12}).*/\1/')"
+
+          payload="$(jq -n \
+              --arg title "${title}" \
+              --arg description "${description}" \
+              --arg url "${RUN_URL}" \
+              --arg repository "${REPOSITORY}" \
+              --arg ref "${REF_NAME}" \
+              --arg tags "${formatted_tags}" \
+              --arg digest "${digest_short}" \
+              --arg ghcrUrl "${GHCR_PACKAGE_URL}" \
+              --arg dockerhubUrl "${DOCKERHUB_URL}" \
+              --argjson color "${color}" \
+              '{
+                username: "Maraudarr Deck Crew",
+                embeds: [{
+                  title: $title,
+                  description: $description,
+                  url: $url,
+                  color: $color,
+                  fields: [
+                    {name: "🗺️ Ship Manifest", value: $repository, inline: true},
+                    {name: "🌿 Drama Ref", value: $ref, inline: true},
+                    {name: "🏷️ Fresh Lewks", value: $tags, inline: false},
+                    {name: "🧾 Registry Fingerprint", value: $digest, inline: false},
+                    {name: "📦 GHCR Treasure Room", value: $ghcrUrl, inline: false},
+                    {name: "🐳 Docker Hub Cabaret", value: $dockerhubUrl, inline: false}
+                  ],
+                  footer: {text: "Maraudarr: plundered, powdered, published"},
+                  timestamp: now | todate
+                }]
+              }')"
+
+          curl \
+              --fail \
+              --silent \
+              --show-error \
+              --header "Content-Type: application/json" \
+              --data "${payload}" \
+              "${DISCORD_WEBHOOK_URL}"
+
+      - name: "Notify Hades Discord: kraken verdict 🦑"
+        if: always()
+        env:
+          DISCORD_HADES_HOOK_URL: ${{ secrets.DISCORD_HADES_HOOK_URL }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
+          GHCR_PACKAGE_URL: ${{ github.server_url }}/${{ github.repository }}/pkgs/container/maraudarr
+          DOCKERHUB_URL: https://hub.docker.com/r/${{ github.repository_owner }}/maraudarr
+          PUBLISHED_TAGS: ${{ steps.metadata.outputs.tags }}
+          PUBLISHED_DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          if [ -z "${DISCORD_HADES_HOOK_URL}" ]; then
+              echo "DISCORD_HADES_HOOK_URL is not set; skipping Hades Discord notification."
+              exit 0
+          fi
+
+          if [ "${JOB_STATUS}" = "success" ]; then
+              title="🌈 Kraken approved the fit"
+              description="Maraudarr escaped the shipyard polished, published, and offensively buoyant. Every architecture got an invite."
+          else
+              title="🦑 Kraken ate the build"
+              description="The registry ritual ended ${JOB_STATUS}. The tentacles deny everything; the logs know better."
+          fi
+          embed_colors=(16711884 15961002 11685080 10181046 15844367 16738740)
+          color="${embed_colors[$((RANDOM % ${#embed_colors[@]}))]}"
+
+          formatted_tags="$(printf '%s\n' "${PUBLISHED_TAGS:-none}" \
+              | sed '/^$/d; s#^'"${GHCR_IMAGE}"':##; s/^/• /')"
+          [ -n "${formatted_tags}" ] || formatted_tags="none"
+          digest_short="$(printf '%s' "${PUBLISHED_DIGEST:-unavailable}" \
+              | sed -E 's/^(sha256:[0-9a-f]{12}).*/\1/')"
+
+          payload="$(jq -n \
+              --arg title "${title}" \
+              --arg description "${description}" \
+              --arg url "${RUN_URL}" \
+              --arg repository "${REPOSITORY}" \
+              --arg ref "${REF_NAME}" \
+              --arg tags "${formatted_tags}" \
+              --arg digest "${digest_short}" \
+              --arg ghcrUrl "${GHCR_PACKAGE_URL}" \
+              --arg dockerhubUrl "${DOCKERHUB_URL}" \
+              --argjson color "${color}" \
+              '{
+                username: "Kraken Build Bureau",
+                embeds: [{
+                  title: $title,
+                  description: $description,
+                  url: $url,
+                  color: $color,
+                  fields: [
+                    {name: "⚓ Moisturized Manifest", value: $repository, inline: true},
+                    {name: "💄 Glossy Ref", value: $ref, inline: true},
+                    {name: "🏷️ Hemmed Tags", value: $tags, inline: false},
+                    {name: "🧾 Salty Sigil", value: $digest, inline: false},
+                    {name: "📦 GHCR Booty Call", value: $ghcrUrl, inline: false},
+                    {name: "🐳 Docker Diva Dock", value: $dockerhubUrl, inline: false}
+                  ],
+                  footer: {text: "Kraken Build Bureau: gay panic, zero-downtime"},
+                  timestamp: now | todate
+                }]
+              }')"
+
+          curl \
+              --fail \
+              --silent \
+              --show-error \
+              --header "Content-Type: application/json" \
+              --data "${payload}" \
+              "${DISCORD_HADES_HOOK_URL}"


### PR DESCRIPTION
## Executive summary

Maraudarr now announces its registry voyages to the same two Discord destinations used by Privateerr, but with its own flamboyant pirate-and-kraken personality. The shipyard is loud, gay, and operational. 💅🏴‍☠️

## What changed

- Added build-start embeds for `DISCORD_WEBHOOK_URL` and `DISCORD_HADES_HOOK_URL`.
- Added `always()` completion embeds covering successful, failed, and cancelled publish jobs.
- Included repository, ref, actor, platforms, published tags, shortened image digest, workflow run, GHCR, and Docker Hub details.
- Kept notifications optional: missing webhook secrets are reported and skipped cleanly.
- Wrote distinct Maraudarr copy and emoji instead of cloning Privateerr's goth couture routine.

## Impact

Notifications begin only after the Maraudarr test job succeeds and the actual multi-architecture publish job starts. Completion messages still run when later publishing steps fail, giving Discord enough gossip to point directly at the logs.

Both webhook secret names are already configured in the Plundarr repository.

## Validation

- `pre-commit run --all-files`
- YAML syntax and formatting
- `actionlint`
- secret detection
- shell linting

✨ Registry couture, but make it seaworthy.