### PR TITLE
Refresh Scorecard after workflow changes

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,6 +2,13 @@ name: "Inspect the Crow's Nest 🦜"
 
 on:
     branch_protection_rule:
+    push:
+        branches:
+            - main
+        paths:
+            - ".github/workflows/**"
+            - ".github/renovate.json"
+            - "renovate.json"
     schedule:
         - cron: "29 8 * * 1"
     workflow_dispatch:


### PR DESCRIPTION
## Summary
- Run the Scorecard workflow after pushes to main that change GitHub workflow or Renovate security configuration files.
- Keep the trigger scoped so Scorecard does not run for ordinary application/config changes.

## Code Scanning Context
- GitHub currently reports 15 open code scanning alerts: 8 pinned dependency, 3 token permission, and 4 repository/process alerts.
- The default branch already has pinned Actions and top-level workflow permissions in the tracked workflow files. This change makes Scorecard rerun when those workflow fixes land or change, so stale SARIF alerts can clear without waiting for the weekly schedule.
- The remaining Branch-Protection, Code-Review, CII-Best-Practices, and Fuzzing alerts require repository settings, review policy, OpenSSF program setup, or a real fuzzing integration.

## Validation
- pre-commit hooks run during commit: check yaml, yamllint, and GitHub Actions workflow lint all passed.