### PR TITLE
Avoid unpinned local pip install in Maraudarr image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,14 +36,16 @@ RUN pip install \
       --require-hashes \
       --requirement /tmp/maraudarr/requirements.txt
 
-COPY README.md pyproject.toml /tmp/maraudarr/
 COPY src /tmp/maraudarr/src
 
-RUN pip install \
-      --disable-pip-version-check \
-      --no-build-isolation \
-      --no-deps \
-      /tmp/maraudarr && \
+RUN site_packages="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    mkdir -p "${site_packages}/maraudarr" && \
+    cp -a /tmp/maraudarr/src/maraudarr/. "${site_packages}/maraudarr/" && \
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'exec python3 -m maraudarr.cli "$@"' \
+      > "${MARAUDARR_BIN_HOME}/venv/bin/maraudarr" && \
+    chmod +x "${MARAUDARR_BIN_HOME}/venv/bin/maraudarr" && \
     pip uninstall --yes setuptools pip && \
     rm -rf /tmp/maraudarr
 


### PR DESCRIPTION
## Summary
- Remove the local `pip install /tmp/maraudarr` command that Scorecard reports as an unpinned pip install.
- Copy Maraudarr source into the build venv directly and write the `maraudarr` console wrapper explicitly.
- Keep third-party dependency installation hash-verified through `requirements.txt`.

## Root Cause
Scorecard alert #19 flags the Dockerfile because local source installs cannot be pinned with `pip --require-hashes` the same way package-index requirements can. The project dependencies were already hash-verified; the unpinned command was only installing Maraudarr itself from the Docker build context.

## Validation
- `pre-commit run --files docker/Dockerfile`
- `make build-maraudarr`
- `docker run --rm --read-only --network none --cap-drop ALL --security-opt no-new-privileges:true --tmpfs /tmp:rw,noexec,nosuid,size=64m ghcr.io/scottgigawatt/maraudarr:latest --help`
- `make test-maraudarr`