### PR TITLE
🐒 Let Maraudarr fuzz around and find out 🌈

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,26 @@
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# Dockerfile: Build Maraudarr's Python fuzz targets with ClusterFuzzLite.
+#
+
+#
+# Use the official Python builder expected by ClusterFuzzLite. The digest keeps
+# the fuzzing toolchain deterministic while Renovate tracks future updates.
+#
+FROM gcr.io/oss-fuzz-base/base-builder-python:v1@sha256:6a3e2f6d0cd402285756257ccec0de734638ce7a955f6099de9a6f83a19b63bd
+
+#
+# Keep the complete checkout together so Maraudarr's self-contained Docker
+# build context and its test harnesses retain their normal repository paths.
+#
+COPY . ${SRC}/plundarr
+WORKDIR ${SRC}/plundarr
+
+#
+# ClusterFuzzLite invokes this script from the conventional OSS-Fuzz source
+# root, independently of the project working directory above.
+#
+COPY .clusterfuzzlite/build.sh ${SRC}/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# build.sh: Install Maraudarr and compile its ClusterFuzzLite targets.
+#
+
+set -eu
+
+#
+# Install only Maraudarr itself. Its interactive dependencies are unnecessary
+# because the fuzz target imports the dependency-free text helper module.
+#
+python3 -m pip install --no-deps "${SRC}/plundarr/docker"
+
+#
+# Package the Atheris harness as the executable expected by ClusterFuzzLite.
+# The builder image provides both Atheris and compile_python_fuzzer.
+#
+compile_python_fuzzer \
+    "${SRC}/plundarr/docker/tests/fuzz/maraudarr_text_fuzzer.py"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# project.yaml: Describe Maraudarr's ClusterFuzzLite language toolchain.
+#
+
+#
+# Select the Python builder, Atheris runtime, and supported sanitizers.
+#
+language: python

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,77 @@
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# fuzzing.yml: Fuzz Maraudarr's text parsers on relevant pull requests.
+#
+
+name: "Rattle Maraudarr's Rigging 🐒"
+
+on:
+    pull_request:
+        branches:
+            - main
+        paths:
+            - ".clusterfuzzlite/**"
+            - ".github/workflows/fuzzing.yml"
+            - "docker/pyproject.toml"
+            - "docker/src/**"
+            - "docker/tests/fuzz/**"
+    workflow_dispatch:
+
+#
+# The actions need only read access. Crashes fail the check and remain available
+# in its artifacts, so this workflow does not need to publish SARIF results.
+#
+permissions:
+    contents: read
+
+jobs:
+    fuzz-maraudarr:
+        name: "Feed Strange Charts to Maraudarr 🗺️"
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}
+            cancel-in-progress: true
+
+        steps:
+            #
+            # Use a named checkout path so ClusterFuzzLite can distinguish the
+            # project from its own build and corpus working directories.
+            #
+            - name: "Grab the Treasure Map 🗺️"
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+              with:
+                  path: plundarr
+                  persist-credentials: false
+
+            #
+            # Build the Python harness with AddressSanitizer instrumentation.
+            # The immutable commit resolves ClusterFuzzLite's signed v1 tag.
+            #
+            - name: "Pack the Fuzzing Cannon 🧨"
+              id: build
+              uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+              with:
+                  language: python
+                  sanitizer: address
+                  project-src-path: plundarr
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            #
+            # Spend two focused minutes exploring changed parser paths. Any
+            # reproducible crash fails the job without granting write access.
+            #
+            - name: "Fire Random Bilge at the Parser 💥"
+              id: run
+              uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+              with:
+                  language: python
+                  sanitizer: address
+                  mode: code-change
+                  fuzz-seconds: 120
+                  output-sarif: false
+                  github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/tests/README.md
+++ b/docker/tests/README.md
@@ -1,3 +1,11 @@
+<!--
+  Copyright 2025-2026 Scott Gigawatt
+
+  Licensed under the Apache License, Version 2.0.
+
+  README.md: Describe Maraudarr's unit, integration, and fuzz testing layout.
+  -->
+
 # Maraudarr Test Hold 🧪
 
 Unit tests here cover catalog resolution, comment-preserving rendering,
@@ -7,3 +15,6 @@ directory generation.
 The repository-level matrix in `test/test-maraudarr-matrix.sh` complements
 these tests with real `docker compose config` validation across representative
 presets and service combinations.
+
+Coverage-guided harnesses live in `fuzz/`. ClusterFuzzLite packages them with
+Atheris and exercises relevant parser changes during pull-request validation.

--- a/docker/tests/fuzz/README.md
+++ b/docker/tests/fuzz/README.md
@@ -1,0 +1,30 @@
+<!--
+  Copyright 2025-2026 Scott Gigawatt
+
+  Licensed under the Apache License, Version 2.0.
+
+  README.md: Explain Maraudarr's coverage-guided fuzzing harnesses.
+  -->
+
+# Maraudarr Fuzz Locker 🐒
+
+These Atheris harnesses feed unexpected text into Maraudarr's parsers while
+ClusterFuzzLite watches the paths exercised by each input. A reproducible crash
+fails the pull-request check and preserves the offending input for inspection.
+
+## Text Parser Harness
+
+`maraudarr_text_fuzzer.py` exercises the comment-preserving helpers that split
+Compose services, locate shared template sections, preserve environment groups,
+and remove optional YAML fragments. Expected `TemplateError` exceptions are
+treated as ordinary rejected input; every other exception remains a crash.
+
+The harness deliberately imports only `maraudarr.text`. This keeps fuzz-only
+dependencies out of the published Maraudarr image and makes each run fast enough
+for pull-request validation.
+
+## Build And Execution
+
+ClusterFuzzLite reads `.clusterfuzzlite/` from the repository root, packages the
+harness with Atheris, and fuzzes relevant pull requests for two minutes. The
+workflow uses read-only permissions and immutable action and image references.

--- a/docker/tests/fuzz/maraudarr_text_fuzzer.py
+++ b/docker/tests/fuzz/maraudarr_text_fuzzer.py
@@ -1,0 +1,93 @@
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# maraudarr_text_fuzzer.py: Fuzz Maraudarr's comment-preserving text helpers.
+#
+
+"""Exercise Maraudarr's raw-text parsers with coverage-guided input."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+
+import atheris
+
+
+#
+# Instrument project imports so Atheris can guide new inputs toward previously
+# unexplored branches in Maraudarr rather than only observing the harness.
+#
+with atheris.instrument_imports():
+    from maraudarr.text import (
+        TemplateError,
+        extract_env_preamble,
+        extract_env_sections,
+        extract_footer,
+        extract_foundation,
+        extract_service,
+        remove_comment_group,
+        strip_yaml_key,
+    )
+
+
+#
+# Bound decoded strings so malformed inputs cannot turn one fuzzing iteration
+# into an unhelpful memory-exhaustion test.
+#
+MAX_SOURCE_CHARACTERS = 65_536
+MAX_NAME_CHARACTERS = 128
+
+
+def _exercise_template_parser(
+    parser: Callable[..., str],
+    *arguments: str,
+) -> None:
+    """Accept documented template rejections and verify successful output."""
+
+    try:
+        rendered = parser(*arguments)
+    except TemplateError:
+        return
+
+    # Every successful extraction normalizes its result to one trailing newline.
+    if not rendered.endswith("\n"):
+        raise AssertionError("A successful template extraction lost its newline.")
+
+
+def fuzz_one_input(data: bytes) -> None:
+    """Pass one coverage-guided byte sequence through every text boundary."""
+
+    provider = atheris.FuzzedDataProvider(data)
+    source = provider.ConsumeUnicodeNoSurrogates(MAX_SOURCE_CHARACTERS)
+    name = provider.ConsumeUnicodeNoSurrogates(MAX_NAME_CHARACTERS)
+
+    # These extractors intentionally reject sources missing their required
+    # marker. Unexpected exception types remain visible to the fuzzing engine.
+    _exercise_template_parser(extract_service, source, name)
+    _exercise_template_parser(extract_foundation, source)
+    _exercise_template_parser(extract_footer, source)
+    _exercise_template_parser(extract_env_preamble, source)
+
+    # These helpers accept arbitrary text and therefore must never need an
+    # expected-exception allowlist.
+    sections = extract_env_sections(source)
+    strip_yaml_key(source, name)
+    remove_comment_group(source, name)
+
+    # Environment sections are normalized individually just like extractions.
+    if any(not section.endswith("\n") for section in sections.values()):
+        raise AssertionError("An environment section lost its trailing newline.")
+
+
+def main() -> None:
+    """Register the Maraudarr target and hand control to Atheris."""
+
+    atheris.Setup(sys.argv, fuzz_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Executive booty summary 🏴‍☠️✨

This PR gives Maraudarr a small, real coverage-guided fuzzing integration instead of merely dismissing OpenSSF Scorecard's repository-level `FuzzingID` finding.

### What changed

- adds a focused Atheris harness under `docker/tests/fuzz/` for Maraudarr's comment-preserving text parsers
- treats documented `TemplateError` rejections as normal while surfacing every unexpected exception as a reproducible crash
- adds a fully commented `.clusterfuzzlite/` Python builder with an immutable base-image digest
- adds a read-only, digest-pinned ClusterFuzzLite pull-request workflow with a focused two-minute run
- documents both the fuzz harness and its place in Maraudarr's existing test organization

### Why this shape

The raw Compose and environment text helpers are Maraudarr's clearest parser boundary. Fuzzing those helpers exercises malformed Unicode, unexpected markers, arbitrary service names, and unusual document structures without adding fuzz-only packages to the published generator image. The runtime remains architecture-neutral, deterministic, and unchanged. Very demure. Very secure. Extremely rainbow monkey business. 🌈🐒

After this lands on `main`, a fresh OpenSSF Scorecard run should recognize the checked-in ClusterFuzzLite deployment.

### Validation

- `pre-commit run --all-files`
- `make test-maraudarr`
  - 18 Python unit tests
  - Maraudarr image fallback checks
  - every representative Docker Compose generation matrix
- verified the pinned `gcr.io/oss-fuzz-base/base-builder-python:v1` manifest digest directly through GCR
- GitHub Actions passed:
  - ClusterFuzzLite built and fuzzed the Atheris target successfully
  - Python and Actions inspection
  - full Maraudarr image, multiarch, Trivy, and pre-commit validation
  - CodeQL

Docker Desktop's local registry client hit an environmental GCR EOF while pulling the builder; GitHub's Linux runner subsequently pulled the toolchain and completed the authoritative build-and-fuzz run successfully.