### PR TITLE
📚 Chart guides, calm Scorecard, and tame the kraken 🧭

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -4,16 +4,17 @@
 #
 # Licensed under the Apache License, Version 2.0.
 #
-# build.sh: Install Maraudarr and compile its ClusterFuzzLite targets.
+# build.sh: Expose Maraudarr source and compile its ClusterFuzzLite targets.
 #
 
 set -eu
 
 #
-# Install only Maraudarr itself. Its interactive dependencies are unnecessary
-# because the fuzz target imports the dependency-free text helper module.
+# Import Maraudarr directly from its checked-in source tree. Avoiding a local
+# pip install keeps the fuzz build dependency-free and prevents Scorecard from
+# treating the project itself as an unhashed package dependency.
 #
-python3 -m pip install --no-deps "${SRC}/plundarr/docker"
+export PYTHONPATH="${SRC}/plundarr/docker/src${PYTHONPATH:+:${PYTHONPATH}}"
 
 #
 # Package the Atheris harness as the executable expected by ClusterFuzzLite.

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -150,12 +150,11 @@ jobs:
               exit 0
           fi
 
-          embed_colors=(16711884 15961002 11685080 10181046 15844367 16738740)
-          color="${embed_colors[$((RANDOM % ${#embed_colors[@]}))]}"
+          color=3447003
 
           payload="$(jq -n \
-              --arg title "🏴‍☠️ Maraudarr entered the shipyard, divas" \
-              --arg description "${WORKFLOW_NAME} slapped on a tricorn and ordered a multi-arch fleet. OSHA has left the chat." \
+              --arg title "🏴‍☠️ Shipyard doors are open" \
+              --arg description "${WORKFLOW_NAME} is building the fleet. Keep hands, feet, and cursed YAML inside the workflow." \
               --arg url "${RUN_URL}" \
               --arg repository "${REPOSITORY}" \
               --arg ref "${REF_NAME}" \
@@ -172,14 +171,14 @@ jobs:
                   url: $url,
                   color: $color,
                   fields: [
-                    {name: "🗺️ Gossip Map", value: $repository, inline: true},
-                    {name: "🌿 Serving Ref", value: $ref, inline: true},
-                    {name: "💅 Chaos Commodore", value: $actor, inline: true},
-                    {name: "🧱 Three-Way Fleet", value: $platforms, inline: false},
-                    {name: "📦 GHCR Treasure Chest", value: $ghcr, inline: false},
-                    {name: "🐳 Docker Hub Cruise", value: $dockerhub, inline: false}
+                    {name: "🗺️ Repository", value: $repository, inline: true},
+                    {name: "🌿 Ref", value: $ref, inline: true},
+                    {name: "🧑‍✈️ Captain", value: $actor, inline: true},
+                    {name: "🧱 Platforms", value: $platforms, inline: false},
+                    {name: "📦 GHCR", value: $ghcr, inline: false},
+                    {name: "🐳 Docker Hub", value: $dockerhub, inline: false}
                   ],
-                  footer: {text: "Maraudarr shipyard: queer, seaworthy, over-accessorized"},
+                  footer: {text: "Maraudarr Shipyard • bolts tightened, YAML questioned"},
                   timestamp: now | todate
                 }]
               }')"
@@ -209,12 +208,11 @@ jobs:
               exit 0
           fi
 
-          embed_colors=(16711884 15961002 11685080 10181046 15844367 16738740)
-          color="${embed_colors[$((RANDOM % ${#embed_colors[@]}))]}"
+          color=10181046
 
           payload="$(jq -n \
-              --arg title "🦑 The kraken put on eyeliner. Build time." \
-              --arg description "${WORKFLOW_NAME} sashayed into dry dock with a cutlass, a blueprint, and absolutely no indoor voice." \
+              --arg title "🦑 Kraken clocked in" \
+              --arg description "${WORKFLOW_NAME} started a multi-arch build. The kraken found the button and accepted no training." \
               --arg url "${RUN_URL}" \
               --arg repository "${REPOSITORY}" \
               --arg ref "${REF_NAME}" \
@@ -231,14 +229,14 @@ jobs:
                   url: $url,
                   color: $color,
                   fields: [
-                    {name: "⚓ Wet Little Repo", value: $repository, inline: true},
-                    {name: "💄 Glossy Ref", value: $ref, inline: true},
-                    {name: "🧜 Summoning Siren", value: $actor, inline: true},
-                    {name: "🧱 Tentacle Rack", value: $platforms, inline: false},
-                    {name: "📦 GHCR Booty", value: $ghcr, inline: false},
-                    {name: "🐳 Docker Diva Dock", value: $dockerhub, inline: false}
+                    {name: "⚓ Repository", value: $repository, inline: true},
+                    {name: "🌿 Ref", value: $ref, inline: true},
+                    {name: "🔘 Button Pusher", value: $actor, inline: true},
+                    {name: "🧱 Platforms", value: $platforms, inline: false},
+                    {name: "📦 GHCR", value: $ghcr, inline: false},
+                    {name: "🐳 Docker Hub", value: $dockerhub, inline: false}
                   ],
-                  footer: {text: "Kraken Build Bureau: salty, sparkly, OCI-compliant"},
+                  footer: {text: "Kraken Build Bureau • too many arms, adequate supervision"},
                   timestamp: now | todate
                 }]
               }')"
@@ -390,7 +388,7 @@ jobs:
       # Report the final job state to both optional Discord destinations. These
       # steps run on success or failure so a broken voyage never disappears.
       #
-      - name: "Notify Discord: fleet gossip 📣"
+      - name: "Notify Discord: build verdict 📣"
         if: always()
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
@@ -410,14 +408,14 @@ jobs:
           fi
 
           if [ "${JOB_STATUS}" = "success" ]; then
-              title="✅ Fleet launched. Wig secured."
-              description="Fresh Maraudarr images are serving multi-arch realness. The registries have been boarded and nobody chipped a nail."
+              title="✅ Fleet launched"
+              description="Maraudarr reached both registries. The manifests agree, which is more than the crew can say."
+              color=3066993
           else
-              title="💥 Shipwreck, but make it fashion"
-              description="The Maraudarr voyage ended ${JOB_STATUS}. Somebody fetch the logs, the lifeboats, and a stronger setting spray."
+              title="💥 Build hit a reef"
+              description="Maraudarr ended ${JOB_STATUS}. The logs have been asked to explain themselves."
+              color=15158332
           fi
-          embed_colors=(16711884 15961002 11685080 10181046 15844367 16738740)
-          color="${embed_colors[$((RANDOM % ${#embed_colors[@]}))]}"
 
           formatted_tags="$(printf '%s\n' "${PUBLISHED_TAGS:-none}" \
               | sed '/^$/d; s#^'"${GHCR_IMAGE}"':##; s/^/• /')"
@@ -444,14 +442,14 @@ jobs:
                   url: $url,
                   color: $color,
                   fields: [
-                    {name: "🗺️ Ship Manifest", value: $repository, inline: true},
-                    {name: "🌿 Drama Ref", value: $ref, inline: true},
-                    {name: "🏷️ Fresh Lewks", value: $tags, inline: false},
-                    {name: "🧾 Registry Fingerprint", value: $digest, inline: false},
-                    {name: "📦 GHCR Treasure Room", value: $ghcrUrl, inline: false},
-                    {name: "🐳 Docker Hub Cabaret", value: $dockerhubUrl, inline: false}
+                    {name: "🗺️ Repository", value: $repository, inline: true},
+                    {name: "🌿 Ref", value: $ref, inline: true},
+                    {name: "🏷️ Tags", value: $tags, inline: false},
+                    {name: "🧾 Digest", value: $digest, inline: false},
+                    {name: "📦 GHCR", value: $ghcrUrl, inline: false},
+                    {name: "🐳 Docker Hub", value: $dockerhubUrl, inline: false}
                   ],
-                  footer: {text: "Maraudarr: plundered, powdered, published"},
+                  footer: {text: "Maraudarr Shipyard • receipts attached"},
                   timestamp: now | todate
                 }]
               }')"
@@ -484,14 +482,14 @@ jobs:
           fi
 
           if [ "${JOB_STATUS}" = "success" ]; then
-              title="🌈 Kraken approved the fit"
-              description="Maraudarr escaped the shipyard polished, published, and offensively buoyant. Every architecture got an invite."
+              title="🦑 Kraken stamped approved"
+              description="Images published on every architecture. The kraken requests credit for standing nearby."
+              color=3066993
           else
-              title="🦑 Kraken ate the build"
-              description="The registry ritual ended ${JOB_STATUS}. The tentacles deny everything; the logs know better."
+              title="🦑 Kraken misplaced the build"
+              description="Publication ended ${JOB_STATUS}. All tentacles point at the logs."
+              color=15158332
           fi
-          embed_colors=(16711884 15961002 11685080 10181046 15844367 16738740)
-          color="${embed_colors[$((RANDOM % ${#embed_colors[@]}))]}"
 
           formatted_tags="$(printf '%s\n' "${PUBLISHED_TAGS:-none}" \
               | sed '/^$/d; s#^'"${GHCR_IMAGE}"':##; s/^/• /')"
@@ -518,14 +516,14 @@ jobs:
                   url: $url,
                   color: $color,
                   fields: [
-                    {name: "⚓ Moisturized Manifest", value: $repository, inline: true},
-                    {name: "💄 Glossy Ref", value: $ref, inline: true},
-                    {name: "🏷️ Hemmed Tags", value: $tags, inline: false},
-                    {name: "🧾 Salty Sigil", value: $digest, inline: false},
-                    {name: "📦 GHCR Booty Call", value: $ghcrUrl, inline: false},
-                    {name: "🐳 Docker Diva Dock", value: $dockerhubUrl, inline: false}
+                    {name: "⚓ Repository", value: $repository, inline: true},
+                    {name: "🌿 Ref", value: $ref, inline: true},
+                    {name: "🏷️ Tags", value: $tags, inline: false},
+                    {name: "🧾 Digest", value: $digest, inline: false},
+                    {name: "📦 GHCR", value: $ghcrUrl, inline: false},
+                    {name: "🐳 Docker Hub", value: $dockerhubUrl, inline: false}
                   ],
-                  footer: {text: "Kraken Build Bureau: gay panic, zero-downtime"},
+                  footer: {text: "Kraken Build Bureau • eight arms, one incident report"},
                   timestamp: now | todate
                 }]
               }')"

--- a/README.md
+++ b/README.md
@@ -261,13 +261,13 @@ Privateerr uses the unmodified upstream
 scripts under their upstream MIT license. Plundarr consumes the published
 Privateerr image and does not vendor those scripts.
 
-## Crew Scrolls 🧭
+### 🧭 Crew Charts & Codes
 
-Got a patch, a bug report, or a cursed sea tale? Grab a quill and join the crew:
-
-- 🛠️ [Contributin' Code Booty](./docs/CONTRIBUTING.md) — send fixes without sinkin' the ship.
-- 🤝 [The Pirate Code](./docs/CODE_OF_CONDUCT.md) — no mutiny, no keelhaul-worthy behavior.
-- 🛡️ [Security Parley](./docs/SECURITY.md) — report leaks before the sharks smell blood.
+| 📜 Shipboard Scroll                                  | ⚓ What It Helps Ye Do                                                     |
+| ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| 🛠️ [Patch the Hull](docs/CONTRIBUTING.md)            | Bring fixes and bright ideas aboard without springing leaks below deck.         |
+| 🤝 [The Crewmate Compact](docs/CODE_OF_CONDUCT.md)   | Keep the deck welcoming, useful, and free of plank-walking nonsense.       |
+| 🔐 [Whisper to the Quartermaster](docs/SECURITY.md)  | Report dangerous leaks privately before the sharks catch their scent.      |
 
 ---
 


### PR DESCRIPTION
## Executive booty summary 🏴‍☠️✨

This follow-up sharpens the README's community navigation, removes an unhashed local package install from the ClusterFuzzLite build, and gives Maraudarr's image-build notifications a shorter, drier sense of humor. The charts scan faster, Scorecard has less to complain about, and Discord no longer receives a theatrical monologue from the shipyard. ⚓

### What changed

- replaces the duplicated `Crew Scrolls` list with a compact `Crew Charts & Codes` table
- keeps the community links and Plundarr-flavored wording intact
- imports Maraudarr directly from `docker/src` during fuzz builds through `PYTHONPATH`
- removes the local `pip install --no-deps` command flagged by Scorecard's `Pinned-Dependencies` check
- rewrites all four image-build Discord embeds with concise shipyard and kraken jokes
- shortens field labels while retaining repository, ref, platform, tag, digest, and registry details
- replaces random embed colors with stable start, success, and failure colors

### Why

The README table matches Plundarr's existing navigation style without copying Privateerr's prose. The fuzz build only needs checked-in source, so installing the project added no value and created an avoidable supply-chain finding. The Discord embeds now communicate build state at a glance and keep their longest custom string to 98 characters—plenty of room before Discord starts throwing furniture. 🦑

### Validation

- `pre-commit run --files .clusterfuzzlite/build.sh README.md`
- `pre-commit run --files .github/workflows/build-and-push.yml`
- `git diff --check`
- direct `maraudarr.text` import from `docker/src`
- notification-copy length check
- GitHub Actions, including ClusterFuzzLite