### PR TITLE
🪝 Give Plundarr's pre-commit hooks a labeled tackle box

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,24 @@
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# .pre-commit-config.yaml: Repository lint, secret, workflow, shell, and YAML
+#                          validation hooks.
+#
+
 repos:
+  #
+  # Scan changed content for hardcoded secrets before it can be committed.
+  #
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1
     hooks:
       - id: gitleaks
 
+  #
+  # Compare detected secrets against the reviewed repository baseline.
+  #
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:
@@ -11,6 +26,10 @@ repos:
         args: ["--baseline", ".secrets.baseline"]
         exclude: package.lock.json
 
+  #
+  # Run general file hygiene, syntax, shebang, and whitespace checks while
+  # leaving generated service templates to their specialized validators.
+  #
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -25,6 +44,9 @@ repos:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
 
+  #
+  # Enforce strict YAML style outside generated service template directories.
+  #
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
@@ -35,11 +57,17 @@ repos:
           - "{extends: default, rules: {document-start: disable, line-length: disable, truthy: disable}}"
         exclude: ^docker/services/(?:homepage/config/|[^/]+/compose\.yml$)
 
+  #
+  # Validate GitHub Actions expressions, permissions, and shell fragments.
+  #
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:
       - id: actionlint
 
+  #
+  # Check project-owned shell scripts for correctness and portability issues.
+  #
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:


### PR DESCRIPTION
## Executive booty summary 🏴‍☠️

This PR documents Plundarr's pre-commit configuration with the same structured, plain-English style used by Plundarrpedia.

### What changed

- adds the established copyright, Apache-2.0, and filename-summary header
- explains the purpose of secret scans, file hygiene, YAML and Actions linting, and ShellCheck
- documents why generated service templates remain outside the general YAML validators
- keeps technical comments sober and concise

### Behavior and impact

This is a comment-only change. Every hook, revision, argument, generated-template exclusion, and ordering remains identical to `main`.

### Validation

- comment-stripped configuration comparison against `main`
- `git diff --check`
- `pre-commit run --all-files`