### PR TITLE
🧭 Add repository-wide EditorConfig consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,38 @@
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# .editorconfig: Keep repository text files and source code consistently
+#                formatted across supported editors.
+#
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{md,yml,yaml}]
+indent_size = 2
+
+[.github/workflows/*.{yml,yaml}]
+indent_size = 4
+
+[*.{json,json5,py,sh,toml}]
+indent_size = 4
+
+[.gitleaks.toml]
+indent_size = 2
+
+[.secrets.baseline]
+indent_size = 2
+
+[Dockerfile]
+indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## What changed

- Added a root `.editorconfig` with UTF-8, LF line endings, final newlines, and trailing-whitespace cleanup.
- Captured the repository's two-space Markdown and YAML style.
- Set four-space indentation for GitHub Actions, JSON/JSON5, Python, shell, TOML, and Dockerfiles.
- Preserved two-space formatting for the generated secrets baseline and Gitleaks configuration.
- Kept Make recipes gloriously tab-powered, as the ancient texts demand. 🏳️‍🌈⚓

## Why

Editors can now apply Plundarr's house style automatically, reducing formatting drift and review noise for future contributors.

This establishes four spaces for future GitHub workflow edits without reformatting existing workflow files in this PR.

## Impact

No runtime or generated-stack behavior changes. This only adds editor formatting guidance.

## Validation

- `pre-commit run --all-files`
- `git diff --cached --check`
