### PR TITLE
🏴‍☠️ Run Privateerr healthchecks without a shell wrapper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,8 +132,8 @@ services:
     healthcheck:
       <<: *default-healthcheck-settings  # Pull in default healthcheck settings
       test:                              # Healthy when healthcheck marker file exists
-        - CMD-SHELL
-        - test -f "$${PRIVATEERR_HEALTHCHECK_MARKER}"
+        - CMD
+        - privateerr-healthcheck
 
   #
   # Define the 'gluetun' service to route traffic through a WireGuard VPN connection.

--- a/docker/services/privateerr/compose.yml
+++ b/docker/services/privateerr/compose.yml
@@ -51,5 +51,5 @@ services:
     healthcheck:
       <<: *default-healthcheck-settings  # Pull in default healthcheck settings
       test:                              # Healthy when healthcheck marker file exists
-        - CMD-SHELL
-        - test -f "$${PRIVATEERR_HEALTHCHECK_MARKER}"
+        - CMD
+        - privateerr-healthcheck

--- a/docker/tests/test_maraudarr.py
+++ b/docker/tests/test_maraudarr.py
@@ -335,8 +335,10 @@ class MaraudarrTests(unittest.TestCase):
                     shell_healthchecks.add(service.id)
                 else:
                     self.assertIn("\n        - CMD\n", compose)
+                if service.id == "privateerr":
+                    self.assertIn("\n        - privateerr-healthcheck\n", compose)
 
-        self.assertEqual(shell_healthchecks, {"privateerr"})
+        self.assertEqual(shell_healthchecks, set())
 
     #
     # Media-server selection and generated filesystem behavior.

--- a/docs/demo/docker-compose.demo.yml
+++ b/docs/demo/docker-compose.demo.yml
@@ -36,8 +36,8 @@ services:
     # Define container healthcheck to verify demo bootstrap completion
     healthcheck:
       test:  # Check the Privateerr health marker
-        - CMD-SHELL
-        - test -f "$${PRIVATEERR_HEALTHCHECK_MARKER}"
+        - CMD
+        - privateerr-healthcheck
 
   #
   # Override the 'gluetun' service for credential-free demonstration startup.


### PR DESCRIPTION
## Summary ✨

- switch Plundarr's generated Privateerr healthcheck from `CMD-SHELL` marker testing to the image-provided `privateerr-healthcheck` command
- keep the checked-in default stack and credential-free Maraudarr demo override aligned with the service chart
- tighten the Maraudarr healthcheck policy test so every service uses direct `CMD` probes and Privateerr's command contract stays explicit

## Why 🧭

This is the Plundarr sister change for [Privateerr #42](https://github.com/scottgigawatt/privateerr/pull/42). That PR adds the POSIX `privateerr-healthcheck` executable to the Privateerr image and removes redundant shell wrappers from its healthchecks. Plundarr should call the image-owned probe directly so marker defaults and overrides remain Privateerr's responsibility. One command, one exit status, zero unnecessary shell drag. 💅🏳️‍🌈

Gluetun already uses the matching direct `CMD` argument array in Plundarr, so no Gluetun chart change is needed here.

## Dependency ⚓

This PR should merge only after Privateerr #42 is merged and an image containing `privateerr-healthcheck` is published for the tags Plundarr supports. Older Privateerr images do not contain that command.

## Validation 🧪

- `make test-maraudarr`
- `make test-maraudarr-unit`
- `make build-maraudarr`
- `pre-commit run --all-files`
- `docker compose --env-file example.env -f docker-compose.yml config --quiet`
- `docker compose --env-file example.env -f docker-compose.yml -f docs/demo/docker-compose.demo.yml config --quiet`
- inspected the locally built Maraudarr image and confirmed its packaged Privateerr chart contains `CMD` plus `privateerr-healthcheck`
- `git diff --cached --check`