### PR TITLE
⚓ Restore Synology Docker socket access

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,3 +56,15 @@ Run at boot with Synology Task Scheduler:
 ```sh
 sh /volume1/docker/plundarr/scripts/synology/entware.sh
 ```
+
+### `synology/docker-socket.sh`
+
+Waits for Container Manager to create `/var/run/docker.sock`, then grants the `docker` group read/write access so trusted group members can run Docker commands without `sudo`.
+
+Before using the script, create a `docker` group in **DSM → Control Panel → User & Group → Group** and add each trusted Docker user to it. Membership in this group grants root-level control of the NAS through Docker.
+
+Create a boot-up task in Synology Task Scheduler, select `root` as the task user, and use this command:
+
+```sh
+sh /volume1/docker/plundarr/scripts/synology/docker-socket.sh
+```

--- a/scripts/synology/docker-socket.sh
+++ b/scripts/synology/docker-socket.sh
@@ -20,6 +20,9 @@
 #   - Assigns the socket to root:docker with group read/write access.
 #
 
+#
+# Exit immediately when a command fails or an unset variable is referenced.
+#
 set -eu
 
 echo "Starting script to configure Docker socket permissions."

--- a/scripts/synology/docker-socket.sh
+++ b/scripts/synology/docker-socket.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# docker-socket.sh: This script is intended to run directly on Synology NAS to
+#                   grant the docker group access to the Docker daemon socket
+#                   after Container Manager starts.
+#
+# Synology can recreate /var/run/docker.sock with root-only group ownership
+# after a reboot or Container Manager update. Run this script as root from a
+# boot-up task after creating a docker group and adding trusted users to it.
+#
+# The script:
+#   - Verifies it is running as root.
+#   - Verifies the Synology docker group exists.
+#   - Waits up to 120 seconds for the Docker daemon socket to appear.
+#   - Assigns the socket to root:docker with group read/write access.
+#
+
+set -eu
+
+echo "Starting script to configure Docker socket permissions."
+
+#
+# Docker socket settings and boot-time wait limits.
+#
+DOCKER_SOCKET="/var/run/docker.sock"
+DOCKER_GROUP="docker"
+WAIT_TIME=0
+MAX_WAIT=120
+WAIT_INTERVAL=2
+
+#
+# Ensure the script is running as root.
+#
+if [ "$(id -u)" != "0" ]; then
+    echo "ERROR: This script must run as root."
+    exit 1
+fi
+
+#
+# Ensure the Synology docker group exists before changing socket ownership.
+#
+if ! synogroup --get "$DOCKER_GROUP" >/dev/null 2>&1; then
+    echo "ERROR: Synology group '$DOCKER_GROUP' does not exist."
+    echo "Create it in DSM and add each trusted Docker user before retrying."
+    exit 1
+fi
+
+#
+# Wait for Container Manager to create the Docker daemon socket during boot.
+#
+while [ ! -S "$DOCKER_SOCKET" ]; do
+    if [ "$WAIT_TIME" -ge "$MAX_WAIT" ]; then
+        echo "ERROR: Docker socket did not appear at $DOCKER_SOCKET after $MAX_WAIT seconds."
+        exit 1
+    fi
+
+    echo "Docker socket is not ready. Waiting..."
+    sleep "$WAIT_INTERVAL"
+    WAIT_TIME=$((WAIT_TIME + WAIT_INTERVAL))
+done
+
+#
+# Grant the docker group read/write access without exposing the socket to
+# untrusted users.
+#
+echo "Setting $DOCKER_SOCKET ownership to root:$DOCKER_GROUP."
+chown "root:$DOCKER_GROUP" "$DOCKER_SOCKET"
+
+echo "Setting $DOCKER_SOCKET permissions to 0660."
+chmod 0660 "$DOCKER_SOCKET"
+
+echo "Docker socket permissions configured successfully."


### PR DESCRIPTION
## Summary

- add an executable `scripts/synology/docker-socket.sh` helper in Plundarr's established shell style
- wait up to 120 seconds for Container Manager to create `/var/run/docker.sock`
- restore `root:docker` ownership and mode `0660` without granting access to all local users
- document DSM group setup, the root Task Scheduler command, and the Docker group's root-equivalent security impact

## Why

Synology can recreate the Docker daemon socket with root-only group ownership after a reboot or Container Manager update. That prevents trusted members of a separately configured `docker` group from using Docker without `sudo` until an administrator repairs the socket permissions.

The boot-up helper makes that repair repeatable while failing clearly when it is not running as root, the Synology `docker` group is missing, or the socket does not appear within the bounded startup window.

## User impact

After the one-time DSM group setup, users can schedule the helper as a root boot-up task and retain Docker CLI access without prefixing each command with `sudo`. Members of the `docker` group still have root-equivalent control through the Docker daemon, so the documentation limits membership to trusted users.

## Validation

- `pre-commit run --files scripts/synology/docker-socket.sh scripts/README.md`
- `sh -n scripts/synology/docker-socket.sh`
- `git diff --cached --check`
- direct non-root execution exits with the expected root-required error