### PR TITLE
🏳️‍🌈 Fix Apprise and Seerr rootless startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,15 @@ x-arr-stack-container: &arr-stack-container  # YAML anchor for arr-stack contain
     <<: *arr-stack-environment               # Pull in the arr-stack environment information
 
 #
+# Containers running directly as the configured unprivileged host identity.
+#
+x-rootless-container: &rootless-container  # YAML anchor for rootless containers
+  <<: *default-container                   # Pull in the default container information
+  user: ${DEFAULT_PUID}:${DEFAULT_PGID}    # Run as the configured host user and primary group
+  group_add:                               # Add the shared media-management group
+    - ${DEFAULT_GROUP}                     # Allow access to group-owned host files
+
+#
 # Labels for containers that should not be updated unattended by Watchtower.
 #
 # Privateerr and Gluetun coordinate VPN configuration, tunnel startup, and
@@ -420,7 +429,7 @@ services:
   #
   seerr:
     # Docker image and container information
-    <<: *default-container                        # Pull in the default container information
+    <<: *rootless-container                       # Pull in the rootless container information
     image: ghcr.io/seerr-team/seerr:${SEERR_TAG}  # Run using the specified tag
     container_name: seerr-${SEERR_TAG}            # Append Docker image tag to container name
     hostname: seerr                               # Set the container hostname

--- a/docker/services/apprise/compose.yml
+++ b/docker/services/apprise/compose.yml
@@ -12,7 +12,7 @@ services:
   #
   apprise:
     # Docker image and container information
-    <<: *default-container                  # Pull in the default container information
+    <<: *rootless-container                 # Pull in the rootless container information
     image: caronc/apprise:${APPRISE_TAG}    # Run using the specified tag
     container_name: apprise-${APPRISE_TAG}  # Append Docker image tag to container name
     hostname: apprise                       # Set the container hostname
@@ -35,3 +35,14 @@ services:
     # Provide writable ephemeral storage required by Nginx and API workers
     tmpfs:
       - /tmp:rw,noexec,nosuid,size=32m  # Store temporary API runtime data in memory
+
+    # Define container healthcheck to verify Apprise API connectivity
+    healthcheck:
+      <<: *default-healthcheck-settings  # Pull in default healthcheck settings
+      test:                              # Check the Apprise API status endpoint
+        - CMD
+        - curl
+        - -fsS
+        - -o
+        - /dev/null
+        - http://127.0.0.1:8000/status

--- a/docker/services/seerr/compose.yml
+++ b/docker/services/seerr/compose.yml
@@ -12,7 +12,7 @@ services:
   #
   seerr:
     # Docker image and container information
-    <<: *default-container                        # Pull in the default container information
+    <<: *rootless-container                       # Pull in the rootless container information
     image: ghcr.io/seerr-team/seerr:${SEERR_TAG}  # Run using the specified tag
     container_name: seerr-${SEERR_TAG}            # Append Docker image tag to container name
     hostname: seerr                               # Set the container hostname

--- a/docker/templates/compose.yml
+++ b/docker/templates/compose.yml
@@ -45,6 +45,15 @@ x-arr-stack-container: &arr-stack-container  # YAML anchor for arr-stack contain
     <<: *arr-stack-environment               # Pull in the arr-stack environment information
 
 #
+# Containers running directly as the configured unprivileged host identity.
+#
+x-rootless-container: &rootless-container  # YAML anchor for rootless containers
+  <<: *default-container                   # Pull in the default container information
+  user: ${DEFAULT_PUID}:${DEFAULT_PGID}    # Run as the configured host user and primary group
+  group_add:                               # Add the shared media-management group
+    - ${DEFAULT_GROUP}                     # Allow access to group-owned host files
+
+#
 # Labels for containers that should not be updated unattended by Watchtower.
 #
 # Privateerr and Gluetun coordinate VPN configuration, tunnel startup, and

--- a/docker/tests/test_maraudarr.py
+++ b/docker/tests/test_maraudarr.py
@@ -130,6 +130,8 @@ class MaraudarrTests(unittest.TestCase):
         self.assertIn("${JELLYFIN_WEBUI_PORT}:8096", compose)
         self.assertIn("${SABNZBD_WEBUI_PORT}:8085", compose)
         self.assertIn("HOMEPAGE_VAR_SONARR_ANIME_KEY", compose)
+        self.assertEqual(2, compose.count("<<: *rootless-container"))
+        self.assertIn("http://127.0.0.1:8000/status", compose)
 
     def test_environment_sections_follow_service_selection(self) -> None:
         """Render environment sections only for the resolved stack plan."""
@@ -309,7 +311,7 @@ class MaraudarrTests(unittest.TestCase):
             with self.subTest(service=service.id):
                 self.assertRegex(
                     compose,
-                    r"<<: \*(?:arr-stack|default)-container",
+                    r"<<: \*(?:arr-stack|default|rootless)-container",
                     f"Service '{service.id}' does not reuse a container anchor.",
                 )
                 if "healthcheck:" in compose:


### PR DESCRIPTION
## What changed

- add a reusable `x-rootless-container` anchor that applies the configured UID, GID, and supplemental group at the Compose runtime boundary
- move Apprise and Seerr onto that anchor without changing the LinuxServer-style `PUID`/`PGID` entrypoint model used by the arr stack
- add an Apprise healthcheck against its API status endpoint
- regenerate the checked-in Plundarr Compose chart and extend generator regression coverage

## Why

Seerr now runs rootless as its image-defined `1000:1000` identity, which could not write a Synology config directory owned by the configured Plundarr identity. Apprise's root startup path attempted to update `/etc/passwd`, which failed because its root filesystem is read-only.

The new anchor makes both services run directly as `${DEFAULT_PUID}:${DEFAULT_PGID}` while retaining `${DEFAULT_GROUP}` access. LinuxServer-style services continue using their supported environment-variable mapping instead of an incompatible blanket `user:` override.

## Impact

Apprise and Seerr can start against existing Synology-owned state without weakening the read-only Apprise filesystem or duplicating identity configuration across service charts. ✨

## Validation

- Apprise runtime probe: `/status` returned HTTP 200
- Seerr 3.4.1 runtime probe: `/api/v1/status` returned HTTP 200
- resolved Compose identity: `1026:101` with supplemental group `101` for both services
- 19 Maraudarr unit tests
- seven-scenario generated Compose matrix
- paired Synology Compose render
- `pre-commit run --all-files`
- `git diff --check`