### PR TITLE
🧷 Pin the developer chart-room wallpaper in place 🌈

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -55,10 +55,26 @@
   --plundarr-surface: rgb(9 35 44 / 76%);
 }
 
+/*
+ * Pin the decorative chart-room glow to the viewport so long documentation
+ * pages scroll over one continuous, non-repeating background.
+ */
 body {
+  isolation: isolate;
+}
+
+body::before {
   background-image:
     radial-gradient(circle at 10% 5%, rgb(45 212 191 / 8%), transparent 25rem),
     radial-gradient(circle at 92% 12%, rgb(214 168 75 / 8%), transparent 22rem);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  content: "";
+  inset: 0;
+  pointer-events: none;
+  position: fixed;
+  z-index: -1;
 }
 
 ::selection {


### PR DESCRIPTION
## Executive summary 🏴‍☠️✨

Pins the Plundarr developer site's chart-room glow to the viewport so long Maraudarr and Python reference pages scroll over one continuous background instead of carrying or repeating the decoration with the document.

## Root cause

The two decorative radial gradients were applied directly to `body` without an explicit attachment, repeat, or sizing model. Browser defaults therefore treated the background as part of the scrolling document and could make it appear tiled across long API pages.

## What changed 🌊

- Moves the existing gradients onto a dedicated `body::before` layer.
- Fixes that noninteractive layer to all four viewport edges.
- Explicitly disables repetition and sizes each gradient to cover the viewport.
- Uses an isolated stacking context so Material navigation, content, and overlays continue rendering above the background.
- Preserves the existing light/dark colors and adds no image, JavaScript, or dependency.

## User impact

The wallpaper stays still while documentation scrolls. Long Python API pages retain the same chart-room identity without visible repetition, and mobile layouts keep their existing responsive behavior.

## Validation 🌈⚓

- `pre-commit run --all-files`
- staged pre-commit suite
- `mkdocs build --strict`
- `git diff --check`
- Visual verification on the 7,000–9,700 px Rendering API page:
  - desktop light and dark palettes
  - deep-page scrolling with the background remaining `position: fixed`
  - 390 × 844 narrow viewport
  - no page-level horizontal overflow
  - no browser console warnings or errors

The chart room now stays put while the paperwork sails by. 🏳️‍🌈🗺️