### PR TITLE
Untangle Renovate's Maraudarr image matchers 🪢✨

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,16 +25,27 @@
     ],
 
     // Track Maraudarr's digest-pinned donor images across every build entrypoint.
+    // Keep direct and shell-default forms separate so each pin is extracted once.
     "customManagers": [
         {
             "customType": "regex",
             "managerFilePatterns": [
                 "/^docker/Dockerfile$/",
-                "/^example\\.maraudarr\\.env$/",
                 "/^\\.github/workflows/build-and-push\\.yml$/"
             ],
             "matchStrings": [
-                "ALPINE_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
+                "ALPINE_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "depNameTemplate": "alpine",
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^example\\.maraudarr\\.env$/"
+            ],
+            "matchStrings": [
                 "ALPINE_TAG=\"\\$\\{ALPINE_TAG:-(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[a-f0-9]+)\\}\""
             ],
             "depNameTemplate": "alpine",
@@ -45,11 +56,21 @@
             "customType": "regex",
             "managerFilePatterns": [
                 "/^docker/Dockerfile$/",
-                "/^example\\.maraudarr\\.env$/",
                 "/^\\.github/workflows/build-and-push\\.yml$/"
             ],
             "matchStrings": [
-                "DOCKER_CLI_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
+                "DOCKER_CLI_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "depNameTemplate": "docker",
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^example\\.maraudarr\\.env$/"
+            ],
+            "matchStrings": [
                 "DOCKER_CLI_TAG=\"\\$\\{DOCKER_CLI_TAG:-(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[a-f0-9]+)\\}\""
             ],
             "depNameTemplate": "docker",
@@ -60,11 +81,21 @@
             "customType": "regex",
             "managerFilePatterns": [
                 "/^docker/Dockerfile$/",
-                "/^example\\.maraudarr\\.env$/",
                 "/^\\.github/workflows/build-and-push\\.yml$/"
             ],
             "matchStrings": [
-                "DOCKER_COMPOSE_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
+                "DOCKER_COMPOSE_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "depNameTemplate": "docker/compose-bin",
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^example\\.maraudarr\\.env$/"
+            ],
+            "matchStrings": [
                 "DOCKER_COMPOSE_TAG=\"\\$\\{DOCKER_COMPOSE_TAG:-(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[a-f0-9]+)\\}\""
             ],
             "depNameTemplate": "docker/compose-bin",


### PR DESCRIPTION
## Summary 🌈⚓

- separate direct Dockerfile/workflow image-pin matches from shell-default environment matches
- give `example.maraudarr.env` dedicated wrapper-aware matchers for Alpine, Docker CLI, and Docker Compose
- prevent Renovate from extracting malformed duplicate versions beginning with `"${...:-`

## Root cause

The broad and wrapper-aware expressions both processed `example.maraudarr.env`. Because Renovate treats each matching expression as an independent dependency, it extracted one valid image tag and one malformed shell expression for each of the three donor images. Those false dependencies produced the lookup warnings shown in [Dependency Dashboard #26](https://github.com/scottgigawatt/plundarr/issues/26).

The matchers now keep their rigging in separate lanes: direct assignments only inspect the Dockerfile and build workflow, while shell-default expressions only inspect the example environment file. No image versions, digests, build behavior, or generated deployment files changed. Clean catches, no regex bycatch, darling. 🏴‍☠️✨

## Validation

- official `renovate/renovate:44.24.0` strict configuration validation
- official Renovate extract-only run: `regex fileCount=9 depCount=10`
- confirmed exactly one valid `example.maraudarr.env` dependency for each donor image and no malformed shell-wrapper captures
- `pre-commit run --all-files`
- `pre-commit run --files .github/renovate.json5`
- `git diff --cached --check`

> [!NOTE]
> After merge, Renovate should be triggered from the manual-job checkbox in Dependency Dashboard #26 so the bot can remove the stale warning.