### PR TITLE
Clarify Maraudarr generation and developer navigation

### DIFF
--- a/docs/development/maraudarr/architecture.md
+++ b/docs/development/maraudarr/architecture.md
@@ -5,22 +5,29 @@ writing so each boundary can be tested without launching the generated stack.
 
 ## Generation Flow
 
-```mermaid
-flowchart LR
-    CLI["CLI<br/>cli.py"]
-    Catalog["Catalog<br/>catalog.py"]
-    Plan["StackPlan<br/>models.py"]
-    Render["Renderers<br/>render.py + text.py"]
-    Stage["Temporary staging directory"]
-    Validate["docker compose config"]
-    Output["Plundarr<br/>Compose + env + config"]
+This is the path of one successful Maraudarr generation run, from the user's
+service choices to safely published Plundarr files and preserved application
+configuration. It describes project generation, not container startup.
 
-    CLI --> Catalog
-    Catalog --> Plan
-    Plan --> Render
-    Render --> Stage
-    Stage --> Validate
-    Validate --> Output
+```mermaid
+%%{init: {"flowchart": {"nodeSpacing": 40, "rankSpacing": 52}, "themeVariables": {"fontSize": "18px"}}}%%
+flowchart TB
+    CLI["🧭 Capture intent<br/><code>cli.py</code>"]
+    Catalog["📚 Resolve the catalog<br/><code>catalog.py</code>"]
+    Plan["📋 Build an immutable StackPlan<br/><code>models.py</code>"]
+    Render["🧩 Render selected fragments<br/><code>render.py + text.py</code>"]
+    Stage["📦 Stage candidate files<br/>temporary output directory"]
+    Validate["🔎 Validate the staged project<br/><code>docker compose config</code>"]
+    Publish["✅ Atomically publish files<br/>Compose + .env + example.env"]
+    Config["🛟 Seed config safely<br/>preserve existing application state"]
+
+    CLI -->|"preset + service choices"| Catalog
+    Catalog -->|"ordered services + dependencies"| Plan
+    Plan -->|"generation contract"| Render
+    Render -->|"candidate project files"| Stage
+    Stage -->|"staged Compose + environment"| Validate
+    Validate -->|"validation passes"| Publish
+    Publish -->|"then apply safe seeds"| Config
 ```
 
 ## 1. Parse Intent

--- a/docs/development/maraudarr/index.md
+++ b/docs/development/maraudarr/index.md
@@ -1,3 +1,7 @@
+---
+icon: material/hammer-wrench
+---
+
 # Maraudarr Developer Overview ⚒️
 
 Maraudarr is the short-lived Python application that assembles a selected

--- a/docs/development/maraudarr/reference/index.md
+++ b/docs/development/maraudarr/reference/index.md
@@ -1,3 +1,7 @@
+---
+icon: material/language-python
+---
+
 # Python Reference Map 🐍
 
 These pages are generated from Maraudarr's public Python docstrings and type

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+icon: material/ship-wheel
+---
+
 # Plundarr Developer Chart Room 🏴‍☠️
 
 Welcome aboard the developer documentation for **Plundarr** and its generator,

--- a/docs/project-guides/index.md
+++ b/docs/project-guides/index.md
@@ -1,0 +1,12 @@
+---
+icon: material/book-open-page-variant
+---
+
+# Project Guides 📖
+
+Pick the chart that matches the work ahead:
+
+- [Set up Plundarr on Synology](../SETUP.md) ⚓
+- [Contribute to the project](../CONTRIBUTING.md) 🛠️
+- [Report a security concern](../SECURITY.md) 🛡️
+- [Review the Code of Conduct](../CODE_OF_CONDUCT.md) 🤝

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Text Helpers: development/maraudarr/reference/text.md
       - Terminal UI: development/maraudarr/reference/ui.md
   - Project Guides:
+      - Guide Map: project-guides/index.md
       - Synology Setup: SETUP.md
       - Contributing: CONTRIBUTING.md
       - Security: SECURITY.md


### PR DESCRIPTION
## What changed ⚓

- turn the Generation Flow diagram into a larger top-to-bottom sequence
- label every transition with the artifact or decision moving forward
- add concise emoji landmarks to make each generation stage easier to scan
- separate atomic file publication from state-preserving config seeding
- explain that the diagram covers project generation, not container startup
- add native Material icons to all four top-level developer documentation tabs
- add a compact Project Guides index so its grouped tab receives an icon without a template hack

## Why these charts needed a glow-up 🌈

The old left-to-right generation chain squeezed seven generic boxes across the page and left every arrow unlabeled. That made the flow difficult to scan and obscured what each boundary actually passes onward. It also grouped config seeding with public file publication even though Maraudarr deliberately performs those operations under different safety rules.

The developer site’s top-level tabs also lacked the visual landmarks used by Plundarrpedia. Material only renders a grouped tab’s page icon when the section begins with a true index page, so Project Guides now has a small guide map alongside its book icon.

The boxes now sail single-file and every major documentation route has its own tiny hat—dramatic, readable, and technically faithful. ✨

## User impact 🏴‍☠️

Readers can follow one successful Maraudarr generation run from service selection through validated publication without mistaking it for container startup. They can also distinguish Chart Room, Maraudarr, Python Reference, and Project Guides more quickly in both desktop tabs and the mobile drawer. Runtime behavior is unchanged.

## Validation 🔎

- `mkdocs build --strict`
- `pre-commit run --all-files`
- local visual QA of the generation flow at desktop and narrow widths
- local visual QA of all four navigation icons in desktop tabs and the mobile drawer