### PR TITLE
Use official Jellyfin image

### DIFF
--- a/docker/services/jellyfin/README.md
+++ b/docker/services/jellyfin/README.md
@@ -1,4 +1,5 @@
 # Jellyfin Service Chart 📽️
 
-Adds a containerized Jellyfin media server with read-only library mounts,
-persistent config and cache paths, and an optional Homepage card.
+Adds the official Jellyfin container image with read-only library mounts,
+persistent config and cache paths, a rootless host identity, and an optional
+Homepage card.

--- a/docker/services/jellyfin/compose.yml
+++ b/docker/services/jellyfin/compose.yml
@@ -12,10 +12,10 @@ services:
   #
   jellyfin:
     # Docker image and container information
-    <<: *rootless-container                         # Pull in rootless container config
-    image: jellyfin/jellyfin:${JELLYFIN_TAG}        # Run the official Jellyfin image
-    container_name: jellyfin-${JELLYFIN_TAG}        # Append Docker image tag to container name
-    hostname: jellyfin                              # Set the container hostname
+    <<: *rootless-container                   # Pull in rootless container config
+    image: jellyfin/jellyfin:${JELLYFIN_TAG}  # Run the official Jellyfin image
+    container_name: jellyfin-${JELLYFIN_TAG}  # Append Docker image tag to container name
+    hostname: jellyfin                        # Set the container hostname
 
     # Define the container environment
     environment:

--- a/docker/services/jellyfin/compose.yml
+++ b/docker/services/jellyfin/compose.yml
@@ -12,10 +12,14 @@ services:
   #
   jellyfin:
     # Docker image and container information
-    <<: *arr-stack-container                             # Pull in arr-stack container config
-    image: lscr.io/linuxserver/jellyfin:${JELLYFIN_TAG}  # Run using the specified tag
-    container_name: jellyfin-${JELLYFIN_TAG}             # Append Docker image tag to container name
-    hostname: jellyfin                                   # Set the container hostname
+    <<: *rootless-container                         # Pull in rootless container config
+    image: jellyfin/jellyfin:${JELLYFIN_TAG}        # Run the official Jellyfin image
+    container_name: jellyfin-${JELLYFIN_TAG}        # Append Docker image tag to container name
+    hostname: jellyfin                              # Set the container hostname
+
+    # Define the container environment
+    environment:
+      <<: *default-environment  # Pull in the default environment information
 
     # Define the host and container ports
     ports:

--- a/docker/tests/test_maraudarr.py
+++ b/docker/tests/test_maraudarr.py
@@ -135,13 +135,15 @@ class MaraudarrTests(unittest.TestCase):
         self.assertIn("# Define the 'apprise' service", compose)
         self.assertIn("# Define the 'jellyfin' service", compose)
         self.assertIn("${APPRISE_API_ONLY}", compose)
+        self.assertIn("image: jellyfin/jellyfin:${JELLYFIN_TAG}", compose)
+        self.assertNotIn("lscr.io/linuxserver/jellyfin", compose)
         self.assertIn("${JELLYFIN_WEBUI_PORT}:8096", compose)
         self.assertIn("${SABNZBD_WEBUI_PORT}:8085", compose)
         self.assertIn("${NZBGET_WEBUI_PORT}:6789", compose)
         self.assertIn("/app/nzbget/nzbget", compose)
         self.assertIn("HOMEPAGE_VAR_NZBGET_USER", compose)
         self.assertIn("HOMEPAGE_VAR_SONARR_ANIME_KEY", compose)
-        self.assertEqual(2, compose.count("<<: *rootless-container"))
+        self.assertEqual(3, compose.count("<<: *rootless-container"))
         self.assertIn("http://127.0.0.1:8000/status", compose)
 
     def test_environment_sections_follow_service_selection(self) -> None:


### PR DESCRIPTION
## What changed

- replace the LinuxServer Jellyfin image with the upstream `jellyfin/jellyfin` image
- run Jellyfin through Maraudarr's rootless UID/GID container anchor instead of the LinuxServer `PUID`/`PGID` contract
- preserve the shared timezone environment
- document the official-image choice and add regression coverage for the rendered image

## Why

The official image provides the shortest upstream support and release path while retaining Jellyfin's application features. Using the existing rootless anchor keeps the generated deployment unprivileged without depending on LinuxServer-specific environment handling.

## Impact

Newly generated stacks that select Jellyfin will pull the official image. Existing generated stacks change only after Maraudarr regenerates their Compose configuration. Persistent `/config`, `/cache`, and media mounts remain unchanged.

## Validation

- `make test-maraudarr`
- `git diff --check`
- repository pre-commit hooks during commit