### PR TITLE
Document every workflow job and preserve YAML spacing 📝🏴‍☠️

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -51,7 +51,7 @@ indent_size = 4
 #
 # Dockerfile continuations use four-space indentation.
 #
-[Dockerfile]
+[Dockerfile,**/Dockerfile]
 indent_size = 4
 
 #

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -162,6 +162,10 @@ jobs:
               --ghcr-image      "${GHCR_IMAGE}" \
               --dockerhub-image "${DOCKERHUB_IMAGE}"
 
+      #
+      # Send the same opening state to the optional Hades destination with its
+      # dedicated notification template.
+      #
       - name: "Notify Hades Discord: kraken awakened 🦑"
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_HADES_HOOK_URL }}
@@ -186,12 +190,22 @@ jobs:
               --ghcr-image      "${GHCR_IMAGE}" \
               --dockerhub-image "${DOCKERHUB_IMAGE}"
 
+      #
+      # Register QEMU emulation so Buildx can assemble every supported target
+      # architecture on the hosted runner.
+      #
       - name: "Summon Cross-Arch Cannons 🧨"
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
 
+      #
+      # Create the Buildx builder that produces one multi-architecture manifest.
+      #
       - name: "Sharpen the Build Axe 🪓"
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
+      #
+      # Authenticate to GHCR with the job-scoped token before publishing images.
+      #
       - name: "Board the GHCR Galleon 🔐"
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
@@ -216,6 +230,9 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !contains(github.ref_name, '-') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
 
+      #
+      # Record one UTC creation timestamp for the image's OCI metadata.
+      #
       - name: "Stamp the Build Time ⏱️"
         id: build-data
         run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "${GITHUB_OUTPUT}"
@@ -248,6 +265,9 @@ jobs:
           sbom: true
           provenance: true
 
+      #
+      # Attach GitHub-verified provenance to the exact GHCR digest just pushed.
+      #
       - name: "Stamp the Provenance Scroll 🧾"
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4
         with:
@@ -264,6 +284,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes skopeo
 
+      #
+      # Copy every published GHCR tag to Docker Hub without rebuilding the image.
+      #
       - name: "Mirror Every Tag to Docker Hub 🐳"
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -280,6 +303,9 @@ jobs:
               --dockerhub-username "${DOCKERHUB_USERNAME}" \
               --published-tags     "${PUBLISHED_TAGS}"
 
+      #
+      # Compare mirrored manifest digests before updating public documentation.
+      #
       - name: "Verify the Registry Mirrors 🔎"
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -340,6 +366,10 @@ jobs:
               --published-tags   "${PUBLISHED_TAGS}" \
               --published-digest "${PUBLISHED_DIGEST}"
 
+      #
+      # Send the same final state to the optional Hades destination even when an
+      # earlier publication step failed.
+      #
       - name: "Notify Hades Discord: kraken verdict 🦑"
         if: always()
         env:

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           persist-credentials: false
 
+      #
+      # Initialize CodeQL for the current matrix language before analysis begins.
+      #
       - name: "Wake the CodeQL Spyglass 🔭"
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4
         with:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -28,6 +28,10 @@ permissions:
   contents: read
 
 jobs:
+  #
+  # Build the instrumented parser harness and exercise it against changed code
+  # within a bounded pull-request runtime.
+  #
   fuzz-maraudarr:
     name: "Feed Strange Charts to Maraudarr 🗺️"
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,6 +49,10 @@ jobs:
       contents: read
 
     steps:
+      #
+      # Fetch the complete read-only history so release tags can be verified
+      # against the main branch before publication.
+      #
       - name: "Grab the Source Charts 📖"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -70,6 +74,9 @@ jobs:
               exit 1
           fi
 
+      #
+      # Install the pinned Python runtime and cache only the locked docs toolchain.
+      #
       - name: "Ready the Python Quill 🪶"
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
@@ -83,12 +90,21 @@ jobs:
       - name: "Load the Documentation Tools 🧰"
         run: make docs-install
 
+      #
+      # Prepare GitHub Pages metadata before rendering and packaging the site.
+      #
       - name: "Configure the Pages Harbor ⚓"
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6
 
+      #
+      # Render the full strict documentation site from its checked-in sources.
+      #
       - name: "Render Every Developer Chart 🔎"
         run: make docs
 
+      #
+      # Package the rendered site as the immutable Pages deployment artifact.
+      #
       - name: "Crate the Static Site 📦"
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
@@ -111,6 +127,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      #
+      # Deploy the previously built artifact and expose its final public URL.
+      #
       - name: "Publish the Developer Charts 🚀"
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5
@@ -130,11 +149,17 @@ jobs:
       contents: read
 
     steps:
+      #
+      # Check out only the helper needed to report the independent job results.
+      #
       - name: "Grab the Notification Helper 🧰"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
+      #
+      # Report build and deployment outcomes to the optional Discord destination.
+      #
       - name: "Notify Discord: documentation verdict 📚"
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -280,12 +280,14 @@
     "[yaml]": {
         "editor.detectIndentation": false,
         "editor.tabSize": 2,
-        "editor.insertSpaces": true
+        "editor.insertSpaces": true,
+        "editor.formatOnSave": false
     },
     "[github-actions-workflow]": {
         "editor.detectIndentation": false,
         "editor.tabSize": 2,
-        "editor.insertSpaces": true
+        "editor.insertSpaces": true,
+        "editor.formatOnSave": false
     },
     "[json][jsonc]": {
         "editor.detectIndentation": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -251,6 +251,7 @@
         "yerself",
         "zipx"
     ],
+
     //
     // Keep Makefile Tools from inventing a configure step for this project.
     //
@@ -264,6 +265,7 @@
         "**/CODEOWNERS": "plaintext",
         "Dockerfile*": "dockerfile"
     },
+
     //
     // Mirror EditorConfig indentation while disabling VS Code auto-detection.
     //


### PR DESCRIPTION
# Pull Request Boarding Pass 🏴‍☠️

## What changed? ⚓

- Added concise plain-English purpose comments before every previously undocumented workflow job and step.
- Completed coverage in the build, CodeQL, fuzzing, and Pages workflows; Scorecard and PR validation were already fully annotated.
- Kept two-space YAML indentation while disabling format-on-save for both `yaml` and `github-actions-workflow` workspace language modes.
- Left the YAML formatter enabled for deliberate manual use while preventing asynchronous saves from collapsing pinned-action comment spacing.
- Included the existing local EditorConfig expansion for nested Dockerfiles and workspace-section spacing cleanup.
- Preserved every trigger, permission, action pin, command, and runtime value.

## Why? 🧭

- Every workflow job and step now explains its intent, security boundary, or place in the publication voyage without making maintainers reverse-engineer the rigging.
- The workspace now stops fighting yamllint and the repository style over the required two spaces before pinned-action comments. Very documented, very demure, extremely seaworthy. ✨

## Test voyage 🧪

- [ ] `make help`
- [ ] `make test`
- [x] `make test-workflows` if workflow helpers changed
- [ ] `make docs` if public or developer documentation changed
- [ ] `make ship PRESET=<preset>` if generation behavior changed
- [ ] `make config PRESET=<preset>` if generated Compose changed
- [ ] `make env PRESET=<preset>` if the generated `.env` shape changed
- [ ] `make build` if the Maraudarr image or build context changed
- [ ] `make test-image` if runtime dependencies or the container contract changed
- [ ] `make build-platforms` if image dependencies or build stages changed
- [ ] `make test-vpn` if validating an already-running Privateerr/Gluetun pair
- [ ] `make test-e2e` if VPN, Privateerr, Gluetun, or downloader behavior changed
- [ ] `make test-stack` if Compose healthchecks, service wiring, or full-stack behavior changed
- [ ] `make restore-test-config PRESET=<preset>` restored example generated config
- [x] `pre-commit run --all-files`

## Secrets check 🛡️

- [x] No real PIA credentials
- [x] No live `wg0.conf`
- [x] No live `privateerr.env`
- [x] No private logs
- [x] No live Duplicati encryption key or Web UI password
- [x] No generated `dist/<preset>/.env` or application state

## Captain notes 📜

- Automated coverage audit confirms all 8 jobs and all 48 named steps across all six workflow YAML files are immediately preceded by a comment.
- Spacing audit confirms all 32 pinned-action comments use exactly two spaces before `#`, with zero one-space violations.
- Comment-only workflow diff audit confirms there are no executable YAML changes.
- The PR copies the remaining local `.editorconfig` and `.vscode/settings.json` changes exactly. 🌈